### PR TITLE
Rename bakery script

### DIFF
--- a/bin/bakery
+++ b/bin/bakery
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 declare(strict_types=1);
 error_reporting(E_ALL);

--- a/bin/bakery
+++ b/bin/bakery
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+error_reporting(E_ALL);
+
+use Neighborhoods\Bakery\Baker;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+$baker = new Baker();
+$baker->bake();

--- a/bin/bakery.php
+++ b/bin/bakery.php
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-error_reporting(E_ALL);
-
-use Neighborhoods\Bakery\Baker;
-
-require_once __DIR__ . '/../vendor/autoload.php';
-$baker = new Baker();
-$baker->bake();

--- a/src/Baker.php
+++ b/src/Baker.php
@@ -107,7 +107,7 @@ class Baker implements BakerInterface
     protected function getRealPaths(array $potentialRealPaths): array
     {
         $realPaths = [];
-        foreach ($this->getRealPathGenerator()($potentialRealPaths) as $potentialRealPath) {
+        foreach ($this->getRealPathClosure()($potentialRealPaths) as $potentialRealPath) {
             if ($potentialRealPath !== false) {
                 $realPaths[] = $potentialRealPath;
             }
@@ -116,7 +116,7 @@ class Baker implements BakerInterface
         return $realPaths;
     }
 
-    protected function getRealPathGenerator() : \Closure
+    protected function getRealPathClosure() : \Closure
     {
         return function (array $potentialRealPaths) {
             foreach ($potentialRealPaths as $potentialRealPath) {

--- a/src/Baker.php
+++ b/src/Baker.php
@@ -79,7 +79,7 @@ class Baker implements BakerInterface
     protected function purgeOpcacheDNSFileCache(): BakerInterface
     {
         $recursiveDirectoryIterator = new \RecursiveDirectoryIterator(
-            __DIR__ . '/../data/cache/Opcache/DNS',
+            __DIR__ . '/../../../../data/cache/Opcache/DNS',
             \RecursiveDirectoryIterator::SKIP_DOTS
         );
 
@@ -98,7 +98,7 @@ class Baker implements BakerInterface
 
     protected function getDIYamlIntermediaryFilePaths(): array
     {
-        $potentialRealPaths[] = __DIR__ . '/../data/cache/expressive.yml';
+        $potentialRealPaths[] = __DIR__ . '/../../../../data/cache/expressive.yml';
         $realPaths = $this->getRealPaths($potentialRealPaths);
 
         return $realPaths;
@@ -116,7 +116,7 @@ class Baker implements BakerInterface
         return $realPaths;
     }
 
-    protected function getRealPathGenerator(): \Generator
+    protected function getRealPathGenerator()
     {
         return function (array $potentialRealPaths) {
             foreach ($potentialRealPaths as $potentialRealPath) {
@@ -161,7 +161,7 @@ class Baker implements BakerInterface
 
     protected function getComposerClassmap(): array
     {
-        return require __DIR__ . '/../vendor/composer/autoload_classmap.php';
+        return require __DIR__ . '/../../../../vendor/composer/autoload_classmap.php';
     }
 
     protected function rm(string $fullFilePath): BakerInterface

--- a/src/Baker.php
+++ b/src/Baker.php
@@ -116,7 +116,7 @@ class Baker implements BakerInterface
         return $realPaths;
     }
 
-    protected function getRealPathGenerator()
+    protected function getRealPathGenerator() : \Closure
     {
         return function (array $potentialRealPaths) {
             foreach ($potentialRealPaths as $potentialRealPath) {


### PR DESCRIPTION
Remove .php suffix
Add shebang line so it can be run without the leading `php`