### PR TITLE
Remove container building from Bakery and compile container files

### DIFF
--- a/src/Baker.php
+++ b/src/Baker.php
@@ -41,7 +41,7 @@ class Baker implements BakerInterface
         $this->opcacheCompileFiles($this->getContainerCacheFiles());
         $this->log('>> Success.');
 
-        $this->log('>> Your Protean product has been successfully baked.');
+        $this->log('>> Your Protean product has been successfully baked. 🤘🤘');
 
         return $this;
     }

--- a/src/Baker.php
+++ b/src/Baker.php
@@ -3,35 +3,21 @@ declare(strict_types=1);
 
 namespace Neighborhoods\Bakery;
 
-use Zend\HttpHandlerRunner\Exception\EmitterException;
-
 class Baker implements BakerInterface
 {
+    const PHP_FILE_EXTENSION_REGEX = '/.php$/';
+
     public function bake(): BakerInterface
     {
         try {
             $this->log('');
             $this->purgeOpcacheDNSFileCaches();
-            $this->purgeDIFileCaches();
             $this->opcacheCompile();
         } catch (\Throwable $throwable) {
             $this->log('>> Error:');
             $this->log($throwable->getMessage());
             $this->log($throwable->getTraceAsString());
         }
-
-        return $this;
-    }
-
-    public function purgeDIFileCaches(): BakerInterface
-    {
-        $this->log(">> Ensuring that the DI container file cache is purged...");
-        $this->purgeDiContainerFileCache();
-        $this->log('>> Success.');
-
-        $this->log(">> Ensuring that the DI YAML intermediary file cache is purged...");
-        $this->purgeDIYAMLIntermediaryFileCache();
-        $this->log('>> Success.');
 
         return $this;
     }
@@ -47,35 +33,15 @@ class Baker implements BakerInterface
 
     protected function opcacheCompile(): BakerInterface
     {
-        $this->log(">> Asking Opcache to compile the Composer authoritative classmap...");
-        $this->opcacheCompileFiles($this->getComposerAuthoritativeClassmap());
+        $this->log(">> Asking Opcache to compile the Composer classmap...");
+        $this->opcacheCompileFiles($this->getComposerClassmap());
         $this->log('>> Success.');
-
-        $this->compileDIContainer();
 
         $this->log('>> Asking Opcache to compile the DI container cache.');
         $this->opcacheCompileFiles($this->getContainerCacheFiles());
         $this->log('>> Success.');
 
-        $this->log('>> Your Protean product has been successfully baked.🤘🤘');
-
-        return $this;
-    }
-
-    protected function compileDIContainer(): BakerInterface
-    {
-        $this->log('>> Including index.php to generate the DI container cache...');
-        ob_start();
-        try {
-            include $this->getIndexFile();
-        } catch (EmitterException $emitterException) {
-            $this->log('>> Intentionally ignoring EmitterException.');
-        } catch (\Throwable $throwable) {
-            ob_clean();
-            throw $throwable;
-        }
-        ob_clean();
-        $this->log('>> Success.');
+        $this->log('>> Your Protean product has been successfully baked.');
 
         return $this;
     }
@@ -100,14 +66,6 @@ class Baker implements BakerInterface
         return $this;
     }
 
-    protected function getDIYamlIntermediaryFilePaths(): array
-    {
-        $potentialRealPaths[] = __DIR__ . '/../../../../data/cache/expressive.yml';
-        $realPaths = $this->getRealPaths($potentialRealPaths);
-
-        return $realPaths;
-    }
-
     protected function getRealPaths(array $potentialRealPaths): array
     {
         $realPaths = [];
@@ -120,7 +78,7 @@ class Baker implements BakerInterface
         return $realPaths;
     }
 
-    protected function getRealPathClosure(): \Closure
+    protected function getRealPathClosure() : \Closure
     {
         return function (array $potentialRealPaths) {
             foreach ($potentialRealPaths as $potentialRealPath) {
@@ -131,26 +89,31 @@ class Baker implements BakerInterface
 
     protected function getContainerCacheFiles(): array
     {
-        $cachedContainerFilePotentialRealPaths = [
-            __DIR__ . '/../../../../data/cache/config-cache.php',
-            __DIR__ . '/../../../../data/cache/container.php',
-        ];
+        $directory = __DIR__ . '/../../../../data/cache';
+        $files = array_diff(scandir($directory), ['.', '..']);
 
-        $cachedContainerFileRealPaths = $this->getRealPaths($cachedContainerFilePotentialRealPaths);
+        $fullFilePaths = [];
+
+        foreach ($files as $file) {
+            if (preg_match(self::PHP_FILE_EXTENSION_REGEX, $file)) {
+                $fullFilePaths[] = $directory . '/' . $file;
+            }
+        }
+
+        $cachedContainerFileRealPaths = $this->getRealPaths($fullFilePaths);
 
         return $cachedContainerFileRealPaths;
     }
-
-    protected function getIndexFile(): string
-    {
-        return realpath(__DIR__ . '/../../../../public/index.php');
-    }
-
+    
     protected function opcacheCompileFiles(array $fullFilePaths): BakerInterface
     {
         foreach ($fullFilePaths as $key => $fullFilePath) {
             if (!opcache_is_script_cached($fullFilePath)) {
-                $this->opcacheCompileFile($fullFilePath);
+                if (opcache_compile_file($fullFilePath)) {
+                    $this->log(sprintf('Opcache has successfully compiled the file: %s', $fullFilePath));
+                } else {
+                    throw new \LogicException(sprintf("Opcache could not compile the file: %s", $fullFilePath));
+                }
             } else {
                 $this->log(sprintf('Opcache has already cached the file: %s', $fullFilePath));
             }
@@ -159,29 +122,9 @@ class Baker implements BakerInterface
         return $this;
     }
 
-    protected function opcacheCompileFile(string $fullFilePath): BakerInterface
+    protected function getComposerClassmap(): array
     {
-        try {
-            if (opcache_compile_file($fullFilePath)) {
-                $this->log(sprintf('Opcache has successfully compiled the file: %s', $fullFilePath));
-            } else {
-                throw new \LogicException(sprintf("Opcache could not compile the file: %s", $fullFilePath));
-            }
-        } catch (\ErrorException $errorException) {
-            $this->log(sprintf('Opcache could not compile the file: %s', $fullFilePath));
-        }
-
-        return $this;
-    }
-
-    protected function getComposerAuthoritativeClassmap(): array
-    {
-        $composerAuthoritativeClassMap = require __DIR__ . '/../../../../vendor/composer/autoload_classmap.php';
-        if (empty($composerAuthoritativeClassMap)) {
-            throw new \RuntimeException('Composer authoritative classmap is empty.');
-        }
-
-        return $composerAuthoritativeClassMap;
+        return require __DIR__ . '/../../../../vendor/composer/autoload_classmap.php';
     }
 
     protected function rm(string $fullFilePath): BakerInterface
@@ -200,24 +143,6 @@ class Baker implements BakerInterface
     protected function log(string $message): BakerInterface
     {
         fwrite(STDOUT, $message . "\n");
-
-        return $this;
-    }
-
-    protected function purgeDiContainerFileCache(): BakerInterface
-    {
-        foreach ($this->getContainerCacheFiles() as $key => $containerCacheFile) {
-            $this->rm($containerCacheFile);
-        }
-
-        return $this;
-    }
-
-    protected function purgeDIYAMLIntermediaryFileCache(): BakerInterface
-    {
-        foreach ($this->getDIYamlIntermediaryFilePaths() as $dIYamlIntermediaryFilePath) {
-            $this->rm($dIYamlIntermediaryFilePath);
-        }
 
         return $this;
     }

--- a/src/Baker.php
+++ b/src/Baker.php
@@ -33,7 +33,7 @@ class Baker implements BakerInterface
 
     protected function opcacheCompile() : BakerInterface
     {
-        $this->log(">> Asking Opcache to compile the Composer classmap...");
+        $this->log(">> Asking Opcache to compile the Composer authoritative classmap...");
         $this->opcacheCompileFiles($this->getComposerAuthoritativeClassmap());
         $this->log('>> Success.');
 


### PR DESCRIPTION
- Removed container building from Bakery since that is now the responsibility of the clients
- Update `getContainerCacheFiles()` to get all container files in `data/cache/` instead of explicitly defined files