### PR TITLE
Building authoritative class map during baking.

### DIFF
--- a/src/Baker.php
+++ b/src/Baker.php
@@ -33,6 +33,9 @@ class Baker implements BakerInterface
 
     protected function opcacheCompile() : BakerInterface
     {
+        $this->log(">> Building Composer authoritative classmap...");
+        exec('composer dump-autoload -a');
+        $this->log('>> Success.');
         $this->log(">> Asking Opcache to compile the Composer authoritative classmap...");
         $this->opcacheCompileFiles($this->getComposerAuthoritativeClassmap());
         $this->log('>> Success.');


### PR DESCRIPTION
Took me quite some time to understand I have to dump-autoload with the -a flag.
I've seen all projects doing that command right in front of bakery, maybe running it as part of the baking process simplifies things