### PR TITLE
Compiling file with multiple classes once

### DIFF
--- a/src/Baker.php
+++ b/src/Baker.php
@@ -34,7 +34,7 @@ class Baker implements BakerInterface
     protected function opcacheCompile() : BakerInterface
     {
         $this->log(">> Asking Opcache to compile the Composer authoritative classmap...");
-        $this->opcacheCompileFiles($this->getComposerAuthoritativeClassmap());
+        $this->opcacheCompileFiles(array_unique($this->getComposerAuthoritativeClassmap()));
         $this->log('>> Success.');
 
         $this->log('>> Asking Opcache to compile the DI container cache.');


### PR DESCRIPTION
I ran bakery on a project having a dependency with two class definitions in the same file. The autoloader class map has the same value (file path) twice with different keyes (class names). As a result opcache_compile_file() was invoked twice on the same file, resulting in an error. This change prevents that from happening.